### PR TITLE
PR for #18: Improve error handling

### DIFF
--- a/lib/shell/run_R.sh
+++ b/lib/shell/run_R.sh
@@ -2,27 +2,59 @@
 
 unset run_R
 run_R () {
+
     # get arguments
     program="$1"
     logfile="$2"
+    OUTPUT_DIR=$(dirname "$logfile")
 
     # set R command if unset
     if [ -z "$rCmd" ]; then
-        echo "No R command set. Using default: Rscript"
+        echo -e "\nNo R command set. Using default: Rscript"
         rCmd="Rscript"
     fi
 
-    # run program, add output to logfile
-    echo "Executing: ${rCmd} ${program}"
-    (
-        ${rCmd} "${program}" 1>> "${logfile}" 2>> "${logfile}"
+    # check if the command exists before running, log error if does not
+    if ! command -v ${rCmd} &> /dev/null; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mProgram error\033[0m at ${error_time}: ${rCmd} not found. Make sure command line usage is properly set up." 
+        echo "Program Error at ${error_time}: ${rCmd} not found." >> "${logfile}"
+        return 1  # exit early with an error code
+    fi
 
-        # report on errors
-        return_code=$?
-        if [ $return_code -ne 0 ]; then
-            # Log an error message if the command failed
-            echo "Error: ${program} failed with exit code $return_code"
+    # capture the content of output folder before running the script
+    files_before=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # log start time for the script
+    echo -e "\nScript ${program} in ${rCmd} started at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+
+    # run command and capture both stdout and stderr in the output variable
+    output=$(${rCmd} "${program}" 2>&1)
+    return_code=$?  # capture the exit status 
+
+    # capture the content of output folder after running the script
+    files_after=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+    # report on errors or success and display the output
+    if [ $return_code -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: ${program} failed at ${error_time}. Check log for details." # display error warning in terminal
+        echo "Error in ${program} at ${error_time}: $output" >> "${logfile}"  # log error output
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: there was an error, but files where created. Check log." 
+            echo -e "\nWarning: There was an error, but these files were created: $created_files" >> "${logfile}"  # log created files
         fi
-    )
+        exit 1 
+    else
+        echo "Script ${program} finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output: $output" >> "${logfile}"  # log output
+        
+        if [ -n "$created_files" ]; then
+        echo -e "\nThe following files were created in ${program}:"  >> "${logfile}" 
+        echo "$created_files" >> "${logfile}" # list files in output folder
+        fi
+    fi
 }
-

--- a/lib/shell/run_latex.sh
+++ b/lib/shell/run_latex.sh
@@ -11,14 +11,16 @@ run_latex() {
     # Set output directory
     # (If no third argument is provided, use the default)
     if [ -n "$3" ]; then
-        outputdir="$3"
+        OUTPUT_DIR="$3"
     else
-        outputdir="../output"
+        OUTPUT_DIR="../output"
     fi
     
     # Clean up
     cleanup() {
-        mv "${programname}.pdf" ${outputdir}
+        if [ -f "${programname}.pdf" ]; then
+        mv "${programname}.pdf" "${OUTPUT_DIR}"
+        fi
         rm -f "${programname}.aux" \
               "${programname}.bbl" \
               "${programname}.blg" \
@@ -35,9 +37,57 @@ run_latex() {
     # Ensure cleanup is called on exit
     trap 'cleanup' EXIT
 
-    
-    echo "Executing: latexmk ${programname}.tex -pdf -bibtex"
-    (latexmk "${programname}.tex" -pdf -bibtex >> "${logfile}" 2>&1)
+    # Check if latexmk command exists
+    if ! command -v latexmk &> /dev/null; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mProgram error\033[0m at ${error_time}: latexmk not found. Ensure LaTeX is installed." 
+        echo "Program Error at ${error_time}: latexmk not found." >> "${logfile}"
+        return 1
+    fi
+ 
+    # capture the content of output folder before running the script
+    files_before=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # log start time for the script
+    echo -e "\nScript ${programname}.tex in latexmk -pdf -bibtex started at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+
+    # run command and capture both stdout and stderr in the output variable
+    output=$(latexmk -interaction=nonstopmode -f "${programname}.tex" -pdf -bibtex 2>&1)
+    return_code=$? # capture the exit status 
+
+    # perform cleanup
+    cleanup
+
+    # capture the content of output folder after running the script
+    files_after=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+    # report on errors or success and display the output
+    if [ $return_code -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: ${programname}.tex failed at ${error_time}. Check log for details." # display error warning in terminal
+        echo "Error in ${programname}.tex at ${error_time}: $output" >> "${logfile}"  # log error output
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: there was an error, but files where created. Check log." 
+            echo -e "\nWarning: There was an error, but these files were created: $created_files" >> "${logfile}"  # log created files
+        fi
+        exit 1 
+    else
+        echo "Script ${programname}.tex finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output: $output" >> "${logfile}"  # log output
+        
+        if [ -n "$created_files" ]; then
+        echo -e "\nThe following files were created in ${programname}.tex:"  >> "${logfile}" 
+        echo "$created_files" >> "${logfile}" # list files in output folder
+        fi
+
+        if [ ! -f "${OUTPUT_DIR}/${programname}.pdf" ]; then
+            echo -e "\033[0;31mWarning\033[0m: No PDF file was created. Check output in log." 
+            echo -e "\nWarning: No PDF file was created. Check output above." >> "${logfile}"  # log warning
+        fi
+    fi
 
 }
 

--- a/lib/shell/run_python.sh
+++ b/lib/shell/run_python.sh
@@ -6,23 +6,54 @@ run_python () {
     # get arguments
     program="$1"
     logfile="$2"
+    OUTPUT_DIR=$(dirname "$logfile")
 
     # set python command if unset
     if [ -z "$pythonCmd" ]; then
-        echo "No python command set. Using default: python"
+        echo -e "\nNo python command set. Using default: python"
         pythonCmd="python"
     fi
 
-    # run program, add output to logfile
-    echo "Executing: ${pythonCmd} ${program}"
-    (
-        ${pythonCmd} ${program} >> "${logfile}"
+    # check if the command exists before running, log error if does not
+    if ! command -v ${pythonCmd} &> /dev/null; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mProgram error\033[0m at ${error_time}: ${pythonCmd} not found. Make sure command line usage is properly set up." 
+        echo "Program Error at ${error_time}: ${pythonCmd} not found." >> "${logfile}"
+        return 1  # exit early with an error code
+    fi
 
-        # report on errors
-        return_code=$?
-        if [ $return_code -ne 0 ]; then
-            # Log an error message if the command failed
-            echo "Error: ${program} failed with exit code $return_code"
+    # capture the content of output folder before running the script
+    files_before=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # log start time for the script
+    echo -e "\nScript ${program} in ${pythonCmd} started at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+
+    # run command and capture both stdout and stderr in the output variable
+    output=$(${pythonCmd} -u "${program}" 2>&1)
+    return_code=$?  # capture the exit status 
+
+    # capture the content of output folder after running the script
+    files_after=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+    # report on errors or success and display the output
+    if [ $return_code -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: ${program} failed at ${error_time}. Check log for details." # display error warning in terminal
+        echo "Error in ${program} at ${error_time}: $output" >> "${logfile}"  # log error output
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: there was an error, but files where created. Check log." 
+            echo -e "\nWarning: There was an error, but these files were created: $created_files" >> "${logfile}"  # log created files
         fi
-    )
+    else
+        echo "Script ${program} finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output: $output" >> "${logfile}"  # log output
+        
+        if [ -n "$created_files" ]; then
+        echo -e "\nThe following files were created in ${program}:"  >> "${logfile}" 
+        echo "$created_files" >> "${logfile}" # list files in output folder
+        fi
+    fi
 }

--- a/lib/shell/run_shell.sh
+++ b/lib/shell/run_shell.sh
@@ -6,20 +6,44 @@ run_shell () {
     # get arguments
     program="$1"
     logfile="$2"
+    OUTPUT_DIR=$(dirname "$logfile")
 
     # set shell command
     shellCmd="$(basename "${SHELL}")"
 
-    # run program, add output to logfile
-    echo "Executing: ${shellCmd} ${program}"
-    (
-        ${shellCmd} ${program} >> "${logfile}"
+    # capture the content of the output folder before running the script
+    files_before=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
 
-        # report on errors
-        return_code=$?
-        if [ $return_code -ne 0 ]; then
-            # Log an error message if the command failed
-            echo "Error: ${program} failed with exit code $return_code"
+    # log start time for the script
+    echo -e "\nScript ${program} in ${shellCmd} started at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+
+    # run command and capture both stdout and stderr in the output variable
+    output=$(${SHELL} "${program}" 2>&1)
+    return_code=$?
+
+    # capture the content of the output folder after running the script
+    files_after=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+     # report on errors or success and display the output
+    if [ $return_code -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: ${program} failed at ${error_time}. Check log for details." # display error warning in terminal
+        echo "Error in ${program} at ${error_time}: $output" >> "${logfile}"  # log error output
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: there was an error, but files where created. Check log." 
+            echo -e "\nWarning: There was an error, but these files were created: $created_files" >> "${logfile}"  # log created files
         fi
-    )
+        exit 1 
+    else
+        echo "Script ${program} finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output: $output" >> "${logfile}"  # log output
+        
+        if [ -n "$created_files" ]; then
+        echo -e "\nThe following files were created in ${program}:"  >> "${logfile}" 
+        echo "$created_files" >> "${logfile}" # list files in output folder
+        fi
+    fi
 }

--- a/lib/shell/run_stata.sh
+++ b/lib/shell/run_stata.sh
@@ -5,26 +5,69 @@ run_stata() {
     # get arguments
     program="$1"
     logfile="$2"
+    OUTPUT_DIR=$(dirname "$logfile")
     programname="${program%.*}"
 
     # set Stata command if unset
     if [ -z "$stataCmd" ]; then
-        echo "No Stata command set. Using default: StataMP"
+        echo -e "\nNo Stata command set. Using default: StataMP"
         stataCmd="StataMP"
     fi
 
-    # run program, add output to logfile
-    echo "Executing: ${stataCmd} ${program}"
-    (
-        ${stataCmd} -b -e do ${program} 1>> "${logfile}" 2>> "${logfile}"
+    # check if the command exists before running, log error if does not
+    if ! command -v ${stataCmd} &> /dev/null; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mProgram error\033[0m at ${error_time}: ${stataCmd} not found. Make sure command line usage is properly set up." 
+        echo "Program Error at ${error_time}: ${stataCmd} not found." >> "${logfile}"
+        exit 1  # exit early with an error code
+    fi
 
-        # report on errors
-        if [ $? -ne 0 ]; then
-            echo "Error: ${program} failed with exit code $return_code" | tee -a "${logfile}"
+    # capture the content of output folder before running the script
+    files_before=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # log start time for the script
+    echo -e "\nScript ${program} in ${stataCmd} started at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+
+    # run command and capture both stdout and stderr in log file
+    ${stataCmd} -e do "${program}" >> "${logfile}" 2>&1
+   
+   # parse the log file to check for Stata error codes like `r(error)`
+    if egrep --before-context=1 --max-count=1 "^r\([0-9]+\);" "${programname}.log" > /dev/null 2>&1; then
+        return_code=1  # set the return code to 1 if any errors were found
+    fi
+
+    # capture the content of output folder after running the script
+    files_after=$(ls -1 "$OUTPUT_DIR" | grep -v "make.log")
+
+    # determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+    # report on errors or success and display the output
+    if [ "${return_code:-0}" -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: ${program} failed at ${error_time}. Check log for details." # display error warning in terminal
+        echo "Error in ${program} at ${error_time}:" >> "${logfile}"  # log error output
+        # add default log to log file and then delete default log
+        cat "${programname}.log" >> "${logfile}"
+        rm "${programname}.log"
+
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: there was an error, but files where created. Check log." 
+            echo -e "\nWarning: There was an error, but these files were created: $created_files" >> "${logfile}"  # log created files
         fi
-    )
+        exit 1 
+    else
+        echo "Script ${program} finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output:" >> "${logfile}"  # log output
 
-    # add default log to log file and then delete default log
-    cat "${programname}.log" >> "${logfile}"
-    rm "${programname}.log"
+        # add default log to log file and then delete default log
+        cat "${programname}.log" >> "${logfile}"
+        rm "${programname}.log"
+        
+        if [ -n "$created_files" ]; then
+        echo -e "\nThe following files were created in ${program}:"  >> "${logfile}" 
+        echo "$created_files" >> "${logfile}" # list files in output folder
+        fi
+    fi
+
 }


### PR DESCRIPTION
**Closes** #18.

**Changes and deliverables:**
In issue #18, I made significant changes to the way errors are handled in the lab template. These changes were pushed in one commit per file, as follows:

- In 796332a, I changed [`run_python.sh`](https://github.com/gentzkow/GentzkowLabTemplate/blob/af61c3e169f972e93e6b46e09bc9813e76fcf31c/lib/shell/run_python.sh)
- In fc0e95e, I changed [`run_R.sh`](https://github.com/gentzkow/GentzkowLabTemplate/blob/af61c3e169f972e93e6b46e09bc9813e76fcf31c/lib/shell/run_R.sh)
- In 182cce5, I changed [`run_stata.sh`](https://github.com/gentzkow/GentzkowLabTemplate/blob/af61c3e169f972e93e6b46e09bc9813e76fcf31c/lib/shell/run_stata.sh)
- In efc8d95, I changed [`run_latex.sh`](https://github.com/gentzkow/GentzkowLabTemplate/blob/af61c3e169f972e93e6b46e09bc9813e76fcf31c/lib/shell/run_latex.sh)
- In 404e2d7, I changed [`run_shell.sh`](https://github.com/gentzkow/GentzkowLabTemplate/blob/af61c3e169f972e93e6b46e09bc9813e76fcf31c/lib/shell/run_shell.sh)
- In af61c3e, I changed all the four `make.sh` files in the [1_data](https://github.com/gentzkow/GentzkowLabTemplate/tree/dd6e30ae46d0e95f49d265dbef98806193566347/1_data), [2_analysis](https://github.com/gentzkow/GentzkowLabTemplate/tree/dd6e30ae46d0e95f49d265dbef98806193566347/2_analysis), [3_slides](https://github.com/gentzkow/GentzkowLabTemplate/tree/dd6e30ae46d0e95f49d265dbef98806193566347/3_slides), and [4_paper](https://github.com/gentzkow/GentzkowLabTemplate/tree/dd6e30ae46d0e95f49d265dbef98806193566347/4_paper) directories


A more detailed explanation for the changes is written in https://github.com/gentzkow/GentzkowLabTemplate/issues/18#issuecomment-2359557206. 

**Review:**
These are significant changes and therefore require a careful and thorough review. My suggested framework for review is as follows:

- [ ] Review the changes and explanations in the scripts and understand the main logic behind them, keeping in mind that one of the goals of these scripts is that they are as direct and short as possible and therefore if you think of ways to make them more efficient, please let me know
- [ ] Run example scripts as usual for R, Python, Stata, shell (run the `my_shell_script`), and compile paper and slides with latex. Check the successful output in the terminal and log files of the whole repository.

> **To test the behavior of error handling, force some errors as follows:**

- [ ] Use a library or command that doesn’t exist in each of the R, Python, Stata and shell scripts, as well as latex
- [ ] Specify a path for the copy inputs line in `make.sh` that leads to a non-existing file
- [ ] Comment out the `run_xx` line for the appropriate language so that the shell script runs into an error like `“run_python command not found"`
- [ ] Try to call a script that doesn’t exist (e.g `run_python fakescript.py`)
- [ ] Change `local_env.sh` so that the paths for each program are wrong (e.g change python3 to python5)
- [ ] To test latex: in `4_paper`, try running `my_project.tex` without copying `my_project.bib` to the source directory (this will cause the latex to compile with errors); also test adding a non-existing jpg to the .tex script

I am assigning either @ShiqiYang2022 , @Xingtong-Jiang , or @linxicindyzeng to review. 

