### PR TITLE
PR for #35: Create new run_rmd command and examples

### DIFF
--- a/examples/rmarkdown/my_report.Rmd
+++ b/examples/rmarkdown/my_report.Rmd
@@ -1,0 +1,36 @@
+---
+title: "O Praeclarum Titulum"
+author:
+  - "Author 1, *Affiliation*"
+  - "Author 2, *Affiliation*"
+date: "`r Sys.Date()`"
+output:
+  pdf_document: default
+geometry: margin=1in
+fontsize: 12pt
+linestretch: 1.5
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE, cache = FALSE)
+
+library(tidyverse)
+```
+
+# Summary
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+```{r}
+data <- read_csv("../input/mpg.csv")
+
+p <- ggplot(data, aes(x = displ, y = cty, color = year)) +
+  geom_point() +
+  xlab("Engine displacement (L)") +
+  ylab("City fuel economy (mpg)")
+
+p
+```
+
+
+

--- a/lib/shell/run_rmd.sh
+++ b/lib/shell/run_rmd.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+unset run_rmd
+run_rmd () {
+    trap - ERR  # Allow internal error handling
+
+    # Get arguments
+    program="$1"    
+    logfile="$2"   
+    OUTPUT_DIR=$(dirname "$logfile")/../output  
+
+    programname=$(basename "$1" .Rmd)
+
+    # Set R command if unset
+    if [ -z "$rCmd" ]; then
+        echo -e "\nNo R command set. Using default: Rscript"
+        rCmd="Rscript"
+    fi
+
+    # Check if the R command exists before running, log error if it does not
+    if ! command -v "${rCmd}" &> /dev/null; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\n\033[0;31mProgram error\033[0m at ${error_time}: ${rCmd} not found. Make sure command line usage is properly set up." 
+        echo "Program Error at ${error_time}: ${rCmd} not found." >> "${logfile}"
+        exit 1  # Exit early with an error code
+    fi
+
+    # Check if the target .Rmd script exists
+    if [ ! -f "${program}" ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\n\033[0;31mProgram error\033[0m at ${error_time}: script ${program} not found." 
+        echo "Program Error at ${error_time}: script ${program} not found." >> "${logfile}"
+        exit 1
+    fi
+
+    # Check and install rmarkdown
+    echo "Checking if 'rmarkdown' package is installed..." >> "${logfile}" 
+    if ! ${rCmd} -e "suppressPackageStartupMessages(library(rmarkdown))" &> /dev/null; then
+        echo -e "\n \033[0;31mWarning\033[0m: The 'rmarkdown' package is not installed."
+        echo -e "Would you like to install 'rmarkdown' globally? (y/n): " 
+        read -r install_choice
+
+        if [[ "$install_choice" == "y" ]]; then
+            echo "Installing 'rmarkdown' package globally..."
+            ${rCmd} -e "install.packages('rmarkdown', repos='http://cran.rstudio.com/')" >> "${logfile}"
+            if [ $? -ne 0 ]; then
+                echo -e "\n\033[0;31mError\033[0m: Failed to install 'rmarkdown'. Please check your R setup or install the package manually." | tee -a "${logfile}"
+                exit 1
+            else
+                echo "'rmarkdown' installed successfully." | tee -a "${logfile}"
+            fi
+        else
+            echo -e "\n\033[0;33mNotice\033[0m: 'rmarkdown' package is required. Please install it within your R environment and rerun the script." | tee -a "${logfile}"
+            exit 1
+        fi
+    else
+        echo "'rmarkdown' package is already installed." >> "${logfile}" 
+    fi
+    
+    # Capture the content of the output folder before running the script
+    if [ -d "${OUTPUT_DIR}" ]; then
+        files_before=$(find "${OUTPUT_DIR}" -type f ! -name "make.log" -exec basename {} + | sort)
+    else
+        mkdir -p "${OUTPUT_DIR}"
+        files_before=""
+    fi
+
+    # Log start time for the script
+    start_time=$(date '+%Y-%m-%d %H:%M:%S')
+    echo -e "\nRendering ${program} started at ${start_time}" | tee -a "${logfile}"
+
+    # Run the R Markdown rendering command and capture both stdout and stderr
+    output=$(${rCmd} -e "rmarkdown::render('${program}', output_dir='${OUTPUT_DIR}', clean=TRUE)" 2>&1)
+    return_code=$?  # Capture the exit status 
+
+    # Capture the content of the output folder after running the script
+    if [ -d "${OUTPUT_DIR}" ]; then
+        files_after=$(find "${OUTPUT_DIR}" -type f ! -name "make.log" -exec basename {} + | sort)
+    else
+        files_after=""
+    fi
+
+    # Determine the new files that were created
+    created_files=$(comm -13 <(echo "$files_before") <(echo "$files_after"))
+
+    # Clean up 
+    rm -f "${programname}.log" 
+
+    # Report on errors or success and display the output
+    if [ $return_code -ne 0 ]; then
+        error_time=$(date '+%Y-%m-%d %H:%M:%S')
+        echo -e "\033[0;31mWarning\033[0m: Rendering ${program} failed at ${error_time}. Check log for details." # Display error warning in terminal
+        echo "Error in rendering ${program} at ${error_time}: $output" >> "${logfile}"  # Log error output
+        if [ -n "$created_files" ]; then
+            echo -e "\033[0;31mWarning\033[0m: An error occurred, but files were created. Check log." 
+            echo -e "\nWarning: An error occurred, but these files were created: $created_files" >> "${logfile}"  # Log created files
+        fi
+        exit 1 
+    else
+        echo "Rendering ${program} finished successfully at $(date '+%Y-%m-%d %H:%M:%S')" | tee -a "${logfile}"
+        echo "Output: $output" >> "${logfile}"  # Log output
+        
+        if [ -n "$created_files" ]; then
+            echo -e "\nThe following files were created during rendering:" >> "${logfile}" 
+            echo "$created_files" >> "${logfile}"  # List files in output folder
+        else
+            echo -e "\nNo new files were created during rendering." >> "${logfile}" 
+        fi
+    fi
+}


### PR DESCRIPTION
**Closes** #35.

**Changes and deliverables:**
In issue #35, created the new [run_rmd.sh](https://github.com/gentzkow/GentzkowLabTemplate/blob/3c30a4bc11b5063417d06990131e097e08cdeea6/lib/shell/run_rmd.sh) command, which is largely based in [run_R.sh](https://github.com/gentzkow/GentzkowLabTemplate/blob/3c30a4bc11b5063417d06990131e097e08cdeea6/lib/shell/run_R.sh). The main difference is that it checks whether the rmarkdown package is installed, and prompts the user to install it if it isn't. It also deletes the default markdown .log file created after the script is rendered.

Second, I wrote a very basic example script [my_report.Rmd ](https://github.com/gentzkow/GentzkowLabTemplate/blob/c58a434baf9a13f4c402254d74e498743f479d61/examples/rmarkdown/my_report.Rmd).

**Review**
Other than reviewing the changes and testing the overall logic of the new command and example, it'd be great to test the robustness for errors in the spirit of #19. 

I am requesting a review from either @Xingtong-Jiang or @ShiqiYang2022. Please let me know if you have any questions. Thanks!