### PR TITLE
PR for #42: Support path resolution on macOS by replacing realpath with pure-shell logic

### DIFF
--- a/1_data/get_inputs.sh
+++ b/1_data/get_inputs.sh
@@ -27,7 +27,7 @@ links_created=false
 for file_path in "${INPUT_FILES[@]}"; do
     if [[ -e "$file_path" ]]; then  # check if the path exists
       file_name=$(basename "$file_path")
-      abs_path=$(realpath "$file_path")  # get absolute path
+      abs_path="$(cd "$(dirname -- "$file_path")" && pwd -P)/$(basename -- "$file_path")"  # get absolute path
       ln -sfn "$abs_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
       links_created=true
     else

--- a/1_data/make.sh
+++ b/1_data/make.sh
@@ -10,8 +10,8 @@ error_handler() {
 
 # Set paths
 # (Make sure REPO_ROOT is set to point to the root of the repository!)
-MAKE_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-REPO_ROOT=$(realpath "$MAKE_SCRIPT_DIR/../")
+MAKE_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$MAKE_SCRIPT_DIR/../" && pwd -P)"
 MODULE=$(basename "$MAKE_SCRIPT_DIR")
 LOGFILE="${MAKE_SCRIPT_DIR}/output/make.log"
 

--- a/2_analysis/get_inputs.sh
+++ b/2_analysis/get_inputs.sh
@@ -27,7 +27,7 @@ links_created=false
 for file_path in "${INPUT_FILES[@]}"; do
     if [[ -e "$file_path" ]]; then  # check if the path exists
       file_name=$(basename "$file_path")
-      abs_path=$(realpath "$file_path")  # get absolute path
+      abs_path="$(cd "$(dirname -- "$file_path")" && pwd -P)/$(basename -- "$file_path")"  # get absolute path
       ln -sfn "$abs_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
       links_created=true
     else

--- a/2_analysis/make.sh
+++ b/2_analysis/make.sh
@@ -10,8 +10,8 @@ error_handler() {
 
 # Set paths
 # (Make sure REPO_ROOT is set to point to the root of the repository!)
-MAKE_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-REPO_ROOT=$(realpath "$MAKE_SCRIPT_DIR/../")
+MAKE_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$MAKE_SCRIPT_DIR/../" && pwd -P)"
 MODULE=$(basename "$MAKE_SCRIPT_DIR")
 LOGFILE="${MAKE_SCRIPT_DIR}/output/make.log"
 

--- a/3_slides/get_inputs.sh
+++ b/3_slides/get_inputs.sh
@@ -27,7 +27,7 @@ links_created=false
 for file_path in "${INPUT_FILES[@]}"; do
     if [[ -e "$file_path" ]]; then  # check if the path exists
       file_name=$(basename "$file_path")
-      abs_path=$(realpath "$file_path")  # get absolute path
+      abs_path="$(cd "$(dirname -- "$file_path")" && pwd -P)/$(basename -- "$file_path")"  # get absolute path
       ln -sfn "$abs_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
       links_created=true
     else

--- a/3_slides/make.sh
+++ b/3_slides/make.sh
@@ -10,8 +10,8 @@ error_handler() {
 
 # Set paths
 # (Make sure REPO_ROOT is set to point to the root of the repository!)
-MAKE_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-REPO_ROOT=$(realpath "$MAKE_SCRIPT_DIR/../")
+MAKE_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$MAKE_SCRIPT_DIR/../" && pwd -P)"
 MODULE=$(basename "$MAKE_SCRIPT_DIR")
 LOGFILE="${MAKE_SCRIPT_DIR}/output/make.log"
 

--- a/4_paper/get_inputs.sh
+++ b/4_paper/get_inputs.sh
@@ -27,7 +27,7 @@ links_created=false
 for file_path in "${INPUT_FILES[@]}"; do
     if [[ -e "$file_path" ]]; then  # check if the path exists
       file_name=$(basename "$file_path")
-      abs_path=$(realpath "$file_path")  # get absolute path
+      abs_path="$(cd "$(dirname -- "$file_path")" && pwd -P)/$(basename -- "$file_path")"  # get absolute path
       ln -sfn "$abs_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
       links_created=true
     else

--- a/4_paper/make.sh
+++ b/4_paper/make.sh
@@ -10,8 +10,8 @@ error_handler() {
 
 # Set paths
 # (Make sure REPO_ROOT is set to point to the root of the repository!)
-MAKE_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-REPO_ROOT=$(realpath "$MAKE_SCRIPT_DIR/../")
+MAKE_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$MAKE_SCRIPT_DIR/../" && pwd -P)"
 MODULE=$(basename "$MAKE_SCRIPT_DIR")
 LOGFILE="${MAKE_SCRIPT_DIR}/output/make.log"
 

--- a/examples/powerpoint/make.sh
+++ b/examples/powerpoint/make.sh
@@ -3,9 +3,9 @@ set -e
 
 # Set paths
 # (Make sure REPO_ROOT is set to point to the root of the repository!)
-MAKE_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-REPO_ROOT=$(realpath "$MAKE_SCRIPT_DIR/../")
-MODULE=$(basename "$MAKE_SCRIPT_DIR")
+MAKE_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$MAKE_SCRIPT_DIR/../" && pwd -P)"
+MODULE="$(basename "$MAKE_SCRIPT_DIR")"
 
 # Tell user what we're doing
 echo -e "\n\nMaking \033[35m${MODULE}\033[0m module with shell: ${SHELL}"

--- a/lib/shell/check_setup.sh
+++ b/lib/shell/check_setup.sh
@@ -2,8 +2,8 @@
 
 # Check if REPO_ROOT is set
 if [ -z "${REPO_ROOT}" ]; then
-    CHECK_SETUP_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-    REPO_ROOT=$(realpath "$CHECK_SETUP_SCRIPT_DIR/../../")
+    CHECK_SETUP_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+    REPO_ROOT="$(cd "$CHECK_SETUP_SCRIPT_DIR/../../" && pwd -P)"
 fi
 
 # Check if local_env.sh exists

--- a/lib/shell/make_externals.sh
+++ b/lib/shell/make_externals.sh
@@ -3,8 +3,8 @@ set -e
 
 # Check if REPO_ROOT is set
 if [ -z "${REPO_ROOT}" ]; then
-    MAKE_EXTERNALS_SCRIPT_DIR=$(dirname "$(realpath "$0")")
-    REPO_ROOT=$(realpath "$MAKE_EXTERNALS_SCRIPT_DIR/../../")
+    MAKE_EXTERNALS_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
+    REPO_ROOT="$(cd "$MAKE_EXTERNALS_SCRIPT_DIR/../.." && pwd -P)"
 fi
 
 source "${REPO_ROOT}/local_env.sh"

--- a/lib/shell/make_externals.sh
+++ b/lib/shell/make_externals.sh
@@ -4,7 +4,7 @@ set -e
 # Check if REPO_ROOT is set
 if [ -z "${REPO_ROOT}" ]; then
     MAKE_EXTERNALS_SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd -P)"
-    REPO_ROOT="$(cd "$MAKE_EXTERNALS_SCRIPT_DIR/../.." && pwd -P)"
+    REPO_ROOT="$(cd "$MAKE_EXTERNALS_SCRIPT_DIR/../../" && pwd -P)"
 fi
 
 source "${REPO_ROOT}/local_env.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ error_handler() {
     exit 1 # early exit with error code
 }
 
-REPO_ROOT=$(dirname "$(realpath "$0")")
+REPO_ROOT="$(cd "$(dirname -- "$0")" && pwd -P)"
 
 # Check if local_env.sh exists
 echo "Checking if local_env.sh exists..."


### PR DESCRIPTION
**Closes**: https://github.com/gentzkow/GentzkowLabTemplate/issues/42

In issue https://github.com/gentzkow/GentzkowLabTemplate/issues/42, I implemented a fix to the template `shell` scripts which caused the template to fail in older versions of MacOS.

**Review**:
Few lines were changed in all `get_inputs.sh` and `make.sh` scripts, as well as in `setup.sh` and `make_externals.sh`. I think going over the changes and testing that the template runs fine (perhaps by running one of the example scripts) is enough.

I'd like to request a review from either @ShiqiYang2022 , @xingtong-jiang or @linxicindyzeng . Please let me know if you have any questions. Thanks!