### PR TITLE
PR for #45: Add input folders to .gitignore to avoid issues with absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # `/temp/` subdirectories are ignored as they are temporary by design
 *temp/
 
+# `/input/` subdirectories are ignored as they contain symlinks with user-specific paths
+*input/
+
 # `/external/` is ignored as it contains user-specific paths
 *external/
 


### PR DESCRIPTION
**Closes #45**

In issue #45, I implemented a minor change to `.gitignore` so that the `input` directory in each module is not commited. Should be easy to review (perhaps worth checking by running an example script). It would also be good to think through whether this is the best approach or the alternative approach mentioned in https://github.com/gentzkow/GentzkowLabTemplate/issues/45#issue-3034455315 is better.

I'd like to request a review from either @ShiqiYang2022 , @xingtong-jiang or @linxicindyzeng . Please let me know if you have any questions. Thanks!