### PR TITLE
PR for #49: Fix issue in get_inputs.sh

### DIFF
--- a/1_data/get_inputs.sh
+++ b/1_data/get_inputs.sh
@@ -14,7 +14,7 @@ INPUT_FILES=(
 )
 
 # Path to current module
-MAKE_SCRIPT_DIR=$(dirname "$0")
+MAKE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Remove existing input directory and recreate it
 rm -rf "${MAKE_SCRIPT_DIR}/input"
@@ -25,9 +25,16 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    if [[ -e "$file_path" ]]; then  # check if the path exists
-      file_name=$(basename "$file_path")
-      ln -sfn "../$file_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
+    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
+    if [[ "$file_path" != /* ]]; then
+      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    else
+      resolved_path="$file_path"
+    fi
+    if [[ -e "$resolved_path" ]]; then  # check if the path exists
+      file_name=$(basename "$resolved_path")
+      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
+      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/2_analysis/get_inputs.sh
+++ b/2_analysis/get_inputs.sh
@@ -14,7 +14,7 @@ INPUT_FILES=(
 )
 
 # Path to current module
-MAKE_SCRIPT_DIR=$(dirname "$0")
+MAKE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Remove existing input directory and recreate it
 rm -rf "${MAKE_SCRIPT_DIR}/input"
@@ -25,9 +25,16 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    if [[ -e "$file_path" ]]; then  # check if the path exists
-      file_name=$(basename "$file_path")
-      ln -sfn "../$file_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
+    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
+    if [[ "$file_path" != /* ]]; then
+      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    else
+      resolved_path="$file_path"
+    fi
+    if [[ -e "$resolved_path" ]]; then  # check if the path exists
+      file_name=$(basename "$resolved_path")
+      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
+      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/3_slides/get_inputs.sh
+++ b/3_slides/get_inputs.sh
@@ -14,7 +14,7 @@ INPUT_FILES=(
 )
 
 # Path to current module
-MAKE_SCRIPT_DIR=$(dirname "$0")
+MAKE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Remove existing input directory and recreate it
 rm -rf "${MAKE_SCRIPT_DIR}/input"
@@ -25,9 +25,16 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    if [[ -e "$file_path" ]]; then  # check if the path exists
-      file_name=$(basename "$file_path")
-      ln -sfn "../$file_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
+    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
+    if [[ "$file_path" != /* ]]; then
+      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    else
+      resolved_path="$file_path"
+    fi
+    if [[ -e "$resolved_path" ]]; then  # check if the path exists
+      file_name=$(basename "$resolved_path")
+      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
+      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/4_paper/get_inputs.sh
+++ b/4_paper/get_inputs.sh
@@ -14,7 +14,7 @@ INPUT_FILES=(
 )
 
 # Path to current module
-MAKE_SCRIPT_DIR=$(dirname "$0")
+MAKE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Remove existing input directory and recreate it
 rm -rf "${MAKE_SCRIPT_DIR}/input"
@@ -25,9 +25,16 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    if [[ -e "$file_path" ]]; then  # check if the path exists
-      file_name=$(basename "$file_path")
-      ln -sfn "../$file_path" "${MAKE_SCRIPT_DIR}/input/$file_name"  # create symlink
+    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
+    if [[ "$file_path" != /* ]]; then
+      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    else
+      resolved_path="$file_path"
+    fi
+    if [[ -e "$resolved_path" ]]; then  # check if the path exists
+      file_name=$(basename "$resolved_path")
+      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
+      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2


### PR DESCRIPTION
**Closes**: https://github.com/gentzkow/GentzkowLabTemplate/issues/49

In issue https://github.com/gentzkow/GentzkowLabTemplate/issues/49, I fixed a bug that created nested folders when calling make.sh from different directories. Specifically, I modified get_inputs.sh to add some lines that force the symlinks target paths to be created relative to the module where get_inputs.sh is.

**Review**:
A general guideline for review is as follows:

Implement one of the typical example script setup in e.g. 1_data. Try calling ./1_data/get_inputs.sh and ./1_data/make.sh from both inside the 1_data directory and from the project root
Verify no nested 1_data/1_data/ directories are created
Test calling ./run_all.sh and verify all modules work correctly
Check that error messages are displayed properly when input files are missing
I'd like to request a review from @xingtong-jiang. Please let me know if you have any questions. Thanks!

note: I had open a previous PR for this issue (#50) but there was a problem when merging so I deleted the branch and opened a new one.