### PR TITLE
PR for #53: Add relative symlinks to get_inputs

### DIFF
--- a/1_data/get_inputs.sh
+++ b/1_data/get_inputs.sh
@@ -33,8 +33,8 @@ for file_path in "${INPUT_FILES[@]}"; do
     fi
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
       file_name=$(basename "$resolved_path")
-      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
-      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
+    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
+    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/1_data/get_inputs.sh
+++ b/1_data/get_inputs.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Define your input paths here
-# Paths may be absolute or relative to the current module.
+# Paths should be relative to the current module.
 # For example, this is a relative path:
 # ../examples/inputs_for_examples/mpg.csv
-# And this is an absolute path:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/mpg.csv.
 # You can also use paths to folders:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/
+# ../examples/inputs_for_examples/
 INPUT_FILES=(
     # /path/to/your/input/file.csv (replace with your actual input paths)
     # Add more input paths as needed
@@ -25,19 +23,14 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
-    if [[ "$file_path" != /* ]]; then
-      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
-    else
-      resolved_path="$file_path"
-    fi
+    resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
-      file_name=$(basename "$resolved_path")
-    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
-    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
-      links_created=true
+        file_name=$(basename "$resolved_path")
+        ln -sfn "../$file_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
+        links_created=true
     else
-      echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
+        echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
     fi
 done
 

--- a/2_analysis/get_inputs.sh
+++ b/2_analysis/get_inputs.sh
@@ -33,8 +33,8 @@ for file_path in "${INPUT_FILES[@]}"; do
     fi
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
       file_name=$(basename "$resolved_path")
-      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
-      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
+    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
+    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/2_analysis/get_inputs.sh
+++ b/2_analysis/get_inputs.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Define your input paths here
-# Paths may be absolute or relative to the current module.
+# Paths should be relative to the current module.
 # For example, this is a relative path:
 # ../examples/inputs_for_examples/mpg.csv
-# And this is an absolute path:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/mpg.csv.
 # You can also use paths to folders:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/
+# ../examples/inputs_for_examples/
 INPUT_FILES=(
     # /path/to/your/input/file.csv (replace with your actual input paths)
     # Add more input paths as needed
@@ -25,19 +23,14 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
-    if [[ "$file_path" != /* ]]; then
-      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
-    else
-      resolved_path="$file_path"
-    fi
+    resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
-      file_name=$(basename "$resolved_path")
-    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
-    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
-      links_created=true
+        file_name=$(basename "$resolved_path")
+        ln -sfn "../$file_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
+        links_created=true
     else
-      echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
+        echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
     fi
 done
 

--- a/3_slides/get_inputs.sh
+++ b/3_slides/get_inputs.sh
@@ -33,8 +33,8 @@ for file_path in "${INPUT_FILES[@]}"; do
     fi
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
       file_name=$(basename "$resolved_path")
-      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
-      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
+    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
+    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/3_slides/get_inputs.sh
+++ b/3_slides/get_inputs.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Define your input paths here
-# Paths may be absolute or relative to the current module.
+# Paths should be relative to the current module.
 # For example, this is a relative path:
 # ../examples/inputs_for_examples/mpg.csv
-# And this is an absolute path:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/mpg.csv.
 # You can also use paths to folders:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/
+# ../examples/inputs_for_examples/
 INPUT_FILES=(
     # /path/to/your/input/file.csv (replace with your actual input paths)
     # Add more input paths as needed
@@ -25,19 +23,14 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
-    if [[ "$file_path" != /* ]]; then
-      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
-    else
-      resolved_path="$file_path"
-    fi
+    resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
-      file_name=$(basename "$resolved_path")
-    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
-    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
-      links_created=true
+        file_name=$(basename "$resolved_path")
+        ln -sfn "../$file_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
+        links_created=true
     else
-      echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
+        echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
     fi
 done
 

--- a/4_paper/get_inputs.sh
+++ b/4_paper/get_inputs.sh
@@ -33,8 +33,8 @@ for file_path in "${INPUT_FILES[@]}"; do
     fi
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
       file_name=$(basename "$resolved_path")
-      absolute_path=$(cd "$(dirname "$resolved_path")" && pwd -P)/$(basename "$resolved_path")
-      ln -sfn "$absolute_path" "$MAKE_SCRIPT_DIR/input/$file_name"  # create symlink in module input dir
+    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
+    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
       links_created=true
     else
       echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2

--- a/4_paper/get_inputs.sh
+++ b/4_paper/get_inputs.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Define your input paths here
-# Paths may be absolute or relative to the current module.
+# Paths should be relative to the current module.
 # For example, this is a relative path:
 # ../examples/inputs_for_examples/mpg.csv
-# And this is an absolute path:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/mpg.csv.
 # You can also use paths to folders:
-# /Users/username/GentzkowLabTemplate/examples/inputs_for_examples/
+# ../examples/inputs_for_examples/
 INPUT_FILES=(
     # /path/to/your/input/file.csv (replace with your actual input paths)
     # Add more input paths as needed
@@ -25,19 +23,14 @@ links_created=false
 
 # Loop through the input paths
 for file_path in "${INPUT_FILES[@]}"; do
-    # Resolve file_path relative to MAKE_SCRIPT_DIR if not absolute
-    if [[ "$file_path" != /* ]]; then
-      resolved_path="$MAKE_SCRIPT_DIR/$file_path"
-    else
-      resolved_path="$file_path"
-    fi
+    resolved_path="$MAKE_SCRIPT_DIR/$file_path"
+    
     if [[ -e "$resolved_path" ]]; then  # check if the path exists
-      file_name=$(basename "$resolved_path")
-    relative_path=$(realpath --relative-to="$MAKE_SCRIPT_DIR/input" "$resolved_path")
-    ln -sfn "$relative_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
-      links_created=true
+        file_name=$(basename "$resolved_path")
+        ln -sfn "../$file_path" "$MAKE_SCRIPT_DIR/input/$file_name" # create symlink in module input dir
+        links_created=true
     else
-      echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
+        echo -e "\033[0;31mWarning\033[0m in \033[0;34mget_inputs.sh\033[0m: $file_path does not exist or is not a valid file path." >&2
     fi
 done
 


### PR DESCRIPTION
**Closes #53** 

We had implemented relative symlinks in get_inputs.sh (https://github.com/gentzkow/GentzkowLabTemplate/pull/46), but this was accidentally reverted while fixing another bug in https://github.com/gentzkow/GentzkowLabTemplate/pull/51. In issue #53 I changed two lines in `get_inputs.sh` to add this back. 

**Review** 

It's worth confirming that both features are now present.

I'd like to request a quick review from @xingtong-jiang . Thanks so much!